### PR TITLE
Update organize_imagenet_webdataset.py

### DIFF
--- a/src/theia/scripts/preprocessing/image_datasets/organize_imagenet_webdataset.py
+++ b/src/theia/scripts/preprocessing/image_datasets/organize_imagenet_webdataset.py
@@ -30,7 +30,7 @@ def check_existing_shard(path: str) -> bool:
         tarf = tarfile.open(path)
         for _ in tarf.getmembers():
             pass
-    except (ValueError, tarfile.ReadError, tarfile.CompressionError) as e:
+    except (FileNotFoundError, ValueError, tarfile.ReadError, tarfile.CompressionError) as e:
         print(e)
         return False
     return True


### PR DESCRIPTION
Previously, the function failed with an unhandled FileNotFoundError when a shard did not yet exist, causing the script to crash on first run. I added FileNotFoundError to the exception handling clause to allow the function to return False in this case, enabling shard creation to proceed as intended.

This change ensures the script behaves correctly when starting from scratch and avoids unnecessary runtime errors.