### PR TITLE
Change to new RAI Institute copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2024 Boston Dynamics AI Institute LLC
+Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import setuptools
 

--- a/src/theia/__init__.py
+++ b/src/theia/__init__.py
@@ -1,1 +1,1 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.

--- a/src/theia/dataset/__init__.py
+++ b/src/theia/dataset/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from .image.image_common import ALL_IMAGE_DATASETS
 from .oxe.oxe_common import ALL_OXE_DATASETS

--- a/src/theia/dataset/data_utils.py
+++ b/src/theia/dataset/data_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 """Defines PyTorch datasets of dataloaders for multiple image, video, and OXE datasets.
 Should use with webdataset >= 0.2.90. See https://github.com/webdataset/webdataset/pull/347"""

--- a/src/theia/dataset/image/__init__.py
+++ b/src/theia/dataset/image/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from .image_common import ALL_IMAGE_DATASETS

--- a/src/theia/dataset/image/image_common.py
+++ b/src/theia/dataset/image/image_common.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from collections import OrderedDict
 

--- a/src/theia/dataset/oxe/__init__.py
+++ b/src/theia/dataset/oxe/__init__.py
@@ -1,1 +1,1 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.

--- a/src/theia/dataset/oxe/oxe_common.py
+++ b/src/theia/dataset/oxe/oxe_common.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from collections import OrderedDict
 from typing import Optional

--- a/src/theia/dataset/oxe/oxe_mixes.py
+++ b/src/theia/dataset/oxe/oxe_mixes.py
@@ -1,4 +1,4 @@
-# File modified. Modifications Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# File modified. Modifications Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 """MIT License Copyright (c) 2023 Robotic AI & Learning Lab Berkeley
 

--- a/src/theia/dataset/oxe/oxe_transforms.py
+++ b/src/theia/dataset/oxe/oxe_transforms.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import torch
 from numpy.typing import NDArray

--- a/src/theia/dataset/video/__init__.py
+++ b/src/theia/dataset/video/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from .video_common import ALL_VIDEO_DATASETS

--- a/src/theia/dataset/video/video_common.py
+++ b/src/theia/dataset/video/video_common.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from collections import OrderedDict
 

--- a/src/theia/decoding/__init__.py
+++ b/src/theia/decoding/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from .decode import decode_everything, load_feature_stats
 from .depth_anything import prepare_depth_decoder

--- a/src/theia/decoding/decode.py
+++ b/src/theia/decoding/decode.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import os
 from typing import Optional

--- a/src/theia/decoding/depth_anything.py
+++ b/src/theia/decoding/depth_anything.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import torch
 import torch.nn as nn

--- a/src/theia/decoding/dinov2.py
+++ b/src/theia/decoding/dinov2.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing import Optional
 

--- a/src/theia/decoding/sam.py
+++ b/src/theia/decoding/sam.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing import Any, Generator, Optional
 

--- a/src/theia/foundation_models/__init__.py
+++ b/src/theia/foundation_models/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from .vision_language_models.clip import get_clip_feature, get_clip_model
 from .vision_language_models.llava import get_llava_vision_model, get_llava_visual_feature

--- a/src/theia/foundation_models/common.py
+++ b/src/theia/foundation_models/common.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import math
 

--- a/src/theia/foundation_models/vision_language_models/__init__.py
+++ b/src/theia/foundation_models/vision_language_models/__init__.py
@@ -1,1 +1,1 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.

--- a/src/theia/foundation_models/vision_language_models/clip.py
+++ b/src/theia/foundation_models/vision_language_models/clip.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import numpy as np
 import torch

--- a/src/theia/foundation_models/vision_language_models/llava.py
+++ b/src/theia/foundation_models/vision_language_models/llava.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from dataclasses import dataclass
 from typing import Optional

--- a/src/theia/foundation_models/vision_models/__init__.py
+++ b/src/theia/foundation_models/vision_models/__init__.py
@@ -1,1 +1,1 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.

--- a/src/theia/foundation_models/vision_models/deit.py
+++ b/src/theia/foundation_models/vision_models/deit.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import numpy as np
 import torch

--- a/src/theia/foundation_models/vision_models/depth_anything.py
+++ b/src/theia/foundation_models/vision_models/depth_anything.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 # File modified.
 
 # -----------------------------------------------------------------------

--- a/src/theia/foundation_models/vision_models/dinov2.py
+++ b/src/theia/foundation_models/vision_models/dinov2.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import numpy as np
 import torch

--- a/src/theia/foundation_models/vision_models/sam.py
+++ b/src/theia/foundation_models/vision_models/sam.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from dataclasses import dataclass
 from typing import Any, Optional

--- a/src/theia/foundation_models/vision_models/vit.py
+++ b/src/theia/foundation_models/vision_models/vit.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import numpy as np
 import torch

--- a/src/theia/lr_schedulers/__init__.py
+++ b/src/theia/lr_schedulers/__init__.py
@@ -1,3 +1,3 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from .lr_schedulers import get_cos_lrs_with_linear_warm_up, get_constant_lrs_with_linear_warm_up

--- a/src/theia/lr_schedulers/lr_schedulers.py
+++ b/src/theia/lr_schedulers/lr_schedulers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing import Any
 from torch.optim import Optimizer

--- a/src/theia/models/__init__.py
+++ b/src/theia/models/__init__.py
@@ -1,1 +1,1 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.

--- a/src/theia/models/activations.py
+++ b/src/theia/models/activations.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import torch.nn as nn
 

--- a/src/theia/models/adapter_heads.py
+++ b/src/theia/models/adapter_heads.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 
 from itertools import chain

--- a/src/theia/models/backbones.py
+++ b/src/theia/models/backbones.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import math
 from typing import Any, Optional

--- a/src/theia/models/feature_translators.py
+++ b/src/theia/models/feature_translators.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import math
 from typing import Any, Optional

--- a/src/theia/models/rvfm.py
+++ b/src/theia/models/rvfm.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing import Any, Optional
 

--- a/src/theia/models/utils.py
+++ b/src/theia/models/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing import Optional
 

--- a/src/theia/models/vfm.py
+++ b/src/theia/models/vfm.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing import Any, Optional
 

--- a/src/theia/optimizers/__init__.py
+++ b/src/theia/optimizers/__init__.py
@@ -1,1 +1,1 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.

--- a/src/theia/optimizers/utils.py
+++ b/src/theia/optimizers/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing import Any, Iterable
 

--- a/src/theia/preprocessing/feature_extraction_core/__init__.py
+++ b/src/theia/preprocessing/feature_extraction_core/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from .models import get_feature_outputs, get_model, get_models
 from .webdataset_utils import check_existing_shard, decode_image_npy_only, read_shard

--- a/src/theia/preprocessing/feature_extraction_core/models.py
+++ b/src/theia/preprocessing/feature_extraction_core/models.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing import Any
 

--- a/src/theia/preprocessing/feature_extraction_core/webdataset_utils.py
+++ b/src/theia/preprocessing/feature_extraction_core/webdataset_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import os
 import tarfile

--- a/src/theia/scripts/decoding/decoding_example.py
+++ b/src/theia/scripts/decoding/decoding_example.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 """
 Example script to decode features from theia model to corresponding visual task output,

--- a/src/theia/scripts/preprocessing/calc_feature_mean.py
+++ b/src/theia/scripts/preprocessing/calc_feature_mean.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 """
 Calculate the channel-wise mean and var of extracted features on ImageNet dataset.

--- a/src/theia/scripts/preprocessing/check_feature.py
+++ b/src/theia/scripts/preprocessing/check_feature.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import argparse
 import json

--- a/src/theia/scripts/preprocessing/feature_extraction.py
+++ b/src/theia/scripts/preprocessing/feature_extraction.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import argparse
 import gc

--- a/src/theia/scripts/preprocessing/image_datasets/organize_imagenet_webdataset.py
+++ b/src/theia/scripts/preprocessing/image_datasets/organize_imagenet_webdataset.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 """Organize imagefolder-like images (ImageNet) to webdataset format."""
 

--- a/src/theia/scripts/preprocessing/iv_feature_extraction.sh
+++ b/src/theia/scripts/preprocessing/iv_feature_extraction.sh
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 #! /bin/bash
 
 dataset=$1

--- a/src/theia/scripts/preprocessing/split_dataset.py
+++ b/src/theia/scripts/preprocessing/split_dataset.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import argparse
 import json

--- a/src/theia/scripts/preprocessing/video_datasets/subsampling_videos.py
+++ b/src/theia/scripts/preprocessing/video_datasets/subsampling_videos.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import argparse
 import os

--- a/src/theia/scripts/train/sanity_check_train_rvfm.sh
+++ b/src/theia/scripts/train/sanity_check_train_rvfm.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 torchrun --nproc_per_node=1 --nnodes 1 --rdzv_backend c10d --rdzv_endpoint localhost:0 scripts/train/train_rvfm.py \
   +logging.note=sanitycheck +dataset.data_portion=0.001

--- a/src/theia/scripts/train/train_rvfm.py
+++ b/src/theia/scripts/train/train_rvfm.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 """
 Training script for theia, also called robot visual foundation model (RVFM) in

--- a/src/theia/utils/__init__.py
+++ b/src/theia/utils/__init__.py
@@ -1,1 +1,1 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.

--- a/src/theia/utils/cortexbench/__init__.py
+++ b/src/theia/utils/cortexbench/__init__.py
@@ -1,1 +1,1 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.

--- a/src/theia/utils/cortexbench/load_model.py
+++ b/src/theia/utils/cortexbench/load_model.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import math
 from typing import Any

--- a/src/theia/utils/cortexbench/policy_heads.py
+++ b/src/theia/utils/cortexbench/policy_heads.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing import Any, Optional
 

--- a/src/theia/utils/cortexbench/transforms.py
+++ b/src/theia/utils/cortexbench/transforms.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import torch
 import torchvision.transforms.v2 as T

--- a/src/theia/utils/cortexbench/trifinger/__init__.py
+++ b/src/theia/utils/cortexbench/trifinger/__init__.py
@@ -1,1 +1,1 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.

--- a/src/theia/utils/cortexbench/trifinger/policy.py
+++ b/src/theia/utils/cortexbench/trifinger/policy.py
@@ -1,4 +1,4 @@
-# File modified. Modifications Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# File modified. Modifications Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # This source code is licensed under the CC-BY-NC license found in the

--- a/src/theia/utils/logging.py
+++ b/src/theia/utils/logging.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from enum import Enum
 from typing import Any

--- a/src/theia/utils/seed.py
+++ b/src/theia/utils/seed.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import os
 import random


### PR DESCRIPTION
Automated update to fix copyright headers with new organization name.

"Boston Dynamics AI Institute LLC" has been changed to "Robotics and AI Institute LLC" or "RAI Institute" for short.

Note that the date-stamps in the copyright headers have been preserved. Only files with existing copyrights have been modified.

This PR was created automatically.