### PR TITLE
Add C-RADIO as a teacher

### DIFF
--- a/src/theia/configs/training/target_models/cddsvr.yaml
+++ b/src/theia/configs/training/target_models/cddsvr.yaml
@@ -1,0 +1,8 @@
+target_model_names:
+ - "google/vit-huge-patch14-224-in21k"
+ - "facebook/dinov2-large"
+ - "openai/clip-vit-large-patch14"
+ - "facebook/sam-vit-huge"
+ - "LiheYoung/depth-anything-large-hf"
+ - "nvidia/C-RADIOv3-H"
+target_model_weights: null

--- a/src/theia/configs/training/target_models/cradio.yaml
+++ b/src/theia/configs/training/target_models/cradio.yaml
@@ -1,0 +1,3 @@
+target_model_names:
+ - "nvidia/C-RADIOv3-H"
+target_model_weights: null

--- a/src/theia/foundation_models/__init__.py
+++ b/src/theia/foundation_models/__init__.py
@@ -2,6 +2,7 @@
 
 from .vision_language_models.clip import get_clip_feature, get_clip_model
 from .vision_language_models.llava import get_llava_vision_model, get_llava_visual_feature
+from .vision_models.cradio import get_cradio_feature, get_cradio_model
 from .vision_models.deit import get_deit_feature, get_deit_model
 from .vision_models.depth_anything import get_depth_anything_feature, get_depth_anything_model
 from .vision_models.dinov2 import get_dinov2_feature, get_dinov2_model

--- a/src/theia/foundation_models/common.py
+++ b/src/theia/foundation_models/common.py
@@ -11,6 +11,7 @@ MODELS = [
     "llava-hf/llava-1.5-7b-hf",
     "openai/clip-vit-large-patch14",
     "LiheYoung/depth-anything-large-hf",
+    "nvidia/C-RADIOv3-H",
 ]
 
 # handy model feature size constants
@@ -22,6 +23,8 @@ MODEL_FEATURE_SIZES = {
     "llava-hf/llava-1.5-7b-hf": (1024, 24, 24),
     "openai/clip-vit-large-patch14": (1024, 16, 16),
     "LiheYoung/depth-anything-large-hf": (32, 64, 64),
+    # C-RADIOv3-H (ViT-H/16): 224 input -> 14x14 spatial tokens, latent dim 1280.
+    "nvidia/C-RADIOv3-H": (1280, 14, 14),
 }
 
 

--- a/src/theia/foundation_models/vision_models/cradio.py
+++ b/src/theia/foundation_models/vision_models/cradio.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
+
+"""C-RADIO teacher for Theia distillation.
+
+C-RADIO (NVIDIA, https://github.com/NVlabs/RADIO) is an agglomerative vision
+foundation model (multi-teacher distillation). The "C-RADIO" weights are
+released under the NVIDIA Open Model License, which permits commercial use, so
+they are usable as a default Theia teacher.
+
+The public C-RADIO checkpoints expose a HuggingFace `AutoModel` with
+`trust_remote_code=True`. A forward pass returns a `(summary, spatial_features)`
+pair:
+    summary          : (B, C_s)      global/CLS-like token
+    spatial_features : (B, N, C)     per-patch tokens, N = (H/patch) * (W/patch)
+
+C-RADIO applies its own ImageNet input conditioning internally, so inputs are
+passed as float pixel values in [0, 1].
+"""
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from transformers import AutoModel
+
+# C-RADIO ViT backbones use patch size 16, so the input resolution must be a
+# multiple of 16. 224 matches the other Theia teachers (224/16 = 14 -> 14x14 =
+# 196 spatial tokens); for C-RADIOv3-H this yields (1280, 14, 14) features.
+CRADIO_INPUT_RESOLUTION = 224
+
+
+def get_cradio_feature(
+    model: torch.nn.Module,
+    processor: None,
+    images: list[np.ndarray],
+    requires_grad: bool = False,
+    resolution: int = CRADIO_INPUT_RESOLUTION,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Get C-RADIO features.
+
+    Args:
+        model (torch.nn.Module): C-RADIO model (HF AutoModel, trust_remote_code).
+        processor (None): unused; C-RADIO conditions its own inputs. Kept for a
+            uniform teacher signature with the other foundation models.
+        images (list[np.ndarray]): images to be encoded, in RGB, uint8, HWC.
+        requires_grad (bool): maintains gradient. Defaults to False.
+        resolution (int): square resolution to resize inputs to. Must be a
+            multiple of the backbone patch size (16).
+
+    Returns:
+        tuple[torch.Tensor, torch.Tensor]: (
+            summary_token:  (B, 1, C_s) global token (CLS-like),
+            visual_tokens:  (B, C, H, W) BCHW spatial features
+        )
+    """
+    # stack -> (B, H, W, C) uint8 -> (B, C, H, W) float in [0, 1]
+    x = torch.stack([torch.from_numpy(np.ascontiguousarray(img)) for img in images]).to(model.device)
+    x = x.permute(0, 3, 1, 2).float() / 255.0
+    x = F.interpolate(x, size=(resolution, resolution), mode="bilinear", align_corners=False)
+
+    if requires_grad:
+        output = model(x)
+    else:
+        with torch.no_grad():
+            output = model(x)
+
+    # RADIO HF checkpoints return a `RadioOutput` (fields: summary, features);
+    # some versions return a plain tuple. Handle both.
+    if isinstance(output, (tuple, list)):
+        summary, spatial_features = output[0], output[1]
+    else:
+        summary, spatial_features = output.summary, output.features
+
+    batch_size, num_patches, num_channels = spatial_features.size()
+    hw = int(np.sqrt(num_patches))
+    visual_tokens = spatial_features.transpose(1, 2).reshape(batch_size, num_channels, hw, hw)  # BCHW
+    summary_token = summary.unsqueeze(1)  # (B, 1, C_s) to mirror the cls_token layout of other teachers
+    return summary_token, visual_tokens
+
+
+def get_cradio_model(
+    model_name: str = "nvidia/C-RADIOv3-H", device: str | torch.device = "cuda"
+) -> tuple[torch.nn.Module, None]:
+    """Get C-RADIO model. No separate processor (input conditioning is internal).
+
+    Args:
+        model_name (str, optional): name of the C-RADIO checkpoint. Defaults to
+            "nvidia/C-RADIOv3-H".
+        device (str | torch.device, optional): device to put the model on. Defaults to "cuda".
+
+    Returns:
+        tuple[torch.nn.Module, None]: C-RADIO model and a `None` processor placeholder.
+    """
+    model = AutoModel.from_pretrained(model_name, trust_remote_code=True).to(device)
+    model.eval()
+    return model, None
+
+
+def print_feature_size(model_name: str = "nvidia/C-RADIOv3-H") -> None:
+    """Print the sizes of features from C-RADIO.
+
+    Handy to confirm the feature dimensions registered in
+    `theia.foundation_models.common.MODEL_FEATURE_SIZES` for a given checkpoint.
+
+    Args:
+        model_name (str, optional): the name of the C-RADIO checkpoint.
+    """
+    import requests
+    from PIL import Image
+
+    url = "http://images.cocodataset.org/val2017/000000039769.jpg"
+    image = [np.array(Image.open(requests.get(url, stream=True).raw).convert("RGB"))]
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model, processor = get_cradio_model(model_name, device=device)
+    summary_token, visual_tokens = get_cradio_feature(model, processor, image)
+    # For C-RADIOv3-H at 224: summary (1, 1, 3840), visual (1, 1280, 14, 14).
+    print(model_name, "summary:", tuple(summary_token.size()), "visual:", tuple(visual_tokens.size()))
+    print("-> set MODEL_FEATURE_SIZES['%s'] = (%d, %d, %d)" % (
+        model_name, visual_tokens.size(1), visual_tokens.size(2), visual_tokens.size(3)
+    ))
+
+
+if __name__ == "__main__":
+    print_feature_size()

--- a/src/theia/preprocessing/feature_extraction_core/models.py
+++ b/src/theia/preprocessing/feature_extraction_core/models.py
@@ -9,6 +9,8 @@ from torch.nn.functional import interpolate
 from theia.foundation_models import (
     get_clip_feature,
     get_clip_model,
+    get_cradio_feature,
+    get_cradio_model,
     get_depth_anything_feature,
     get_depth_anything_model,
     get_dinov2_feature,
@@ -35,6 +37,8 @@ def get_model(model_name: str, device: int | str | torch.device = "cpu") -> tupl
         model, processor = get_llava_vision_model(model_name, device=device)
     elif "depth-anything" in model_name:
         model, processor = get_depth_anything_model(model_name, device=device, selected_feature="head")
+    elif "radio" in model_name.lower():
+        model, processor = get_cradio_model(model_name, device=device)
     else:
         raise NotImplementedError(f"{model_name} is not implemented")
     return model, processor
@@ -91,6 +95,12 @@ def get_feature_outputs(
     elif "depth-anything" in model_name:
         feature = get_depth_anything_feature(model, processor, batch_images)
         features[model_name] = {"embedding": interpolate(feature, (64, 64)).detach().cpu().to(dtype).contiguous()}
+    elif "radio" in model_name.lower():
+        summary_token, visual_tokens = get_cradio_feature(model, processor, batch_images)
+        features[model_name] = {
+            "embedding": visual_tokens.detach().cpu().to(dtype).contiguous(),
+            "cls_token": summary_token.detach().cpu().to(dtype).contiguous(),
+        }
     else:
         raise NotImplementedError(f"model {model_name} is not supported")
 


### PR DESCRIPTION
### Summary

Adds C-RADIO (`nvidia/C-RADIOv3-H`) as a distillation teacher.

C-RADIO is an agglomerative (multi-teacher-distillation) VFM whose weights are under the NVIDIA Open Model License, which permits commercial use — so it works as a default teacher. It fits the existing setup directly: translator heads are sized from `MODEL_FEATURE_SIZES`, so it slots in with no architecture changes.

### Changes

- `foundation_models/vision_models/cradio.py` — `get_cradio_model` / `get_cradio_feature`, mirroring the existing teacher modules. Input conditioning is handled internally by C-RADIO (pixels passed in `[0, 1]`); a forward pass returns `(summary, spatial_features)`, reshaped to `(B, C, H, W)`.
- `foundation_models/__init__.py` — export the two functions.
- `preprocessing/feature_extraction_core/models.py` — dispatch branches in `get_model` and `get_feature_outputs`.
- `foundation_models/common.py` — add `nvidia/C-RADIOv3-H` to `MODELS` and `MODEL_FEATURE_SIZES` (`(1280, 14, 14)`).
- `configs/training/target_models/cradio.yaml` — C-RADIO as a single teacher.
- `configs/training/target_models/cddsvr.yaml` — the existing `cddsv` full set plus C-RADIO.

### Testing

Verified locally on a single GPU:

- Loads via `AutoModel.from_pretrained("nvidia/C-RADIOv3-H", trust_remote_code=True)`; spatial features are `(1280, 14, 14)` at 224 input, matching the registered size.
- A DeiT-tiny student distills C-RADIO both on its own and jointly alongside the existing teachers (DINOv2 / CLIP / ViT), with the per-teacher losses decreasing and cosine similarity to the teacher features rising.

### Notes

- Feature-normalization stats (mean/var) for the new teacher are generated from the dataset with the existing `scripts/preprocessing/calc_feature_mean.py`, as documented for the other teachers. Happy to commit the `.npy` files if you'd prefer them in-tree.
- The checkpoint (`nvidia/C-RADIOv3-H`) and config naming are easy to change if you'd prefer a different variant or convention.
- `C-RADIO`'s `trust_remote_code` path pulls in `timm`, `einops`, and `open_clip_torch`; I can add these to the dependencies if you'd like.
